### PR TITLE
Kotlincflags

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -25,10 +25,11 @@ android_app {
     "telephony-common",
   ],
 
-  kotlincflags: {
+  kotlincflags: [
     // -Werror
-    warningerrors: true,
-  },
+    "-Werror",
+    "-verbose",
+  ],
 
   optimize: {
     optimize: true,

--- a/Android.bp
+++ b/Android.bp
@@ -26,7 +26,6 @@ android_app {
   ],
 
   kotlincflags: [
-    // -Werror
     "-Werror",
     "-verbose",
   ],

--- a/Android.bp
+++ b/Android.bp
@@ -25,6 +25,11 @@ android_app {
     "telephony-common",
   ],
 
+  kotlincflags: {
+    // -Werror
+    warningerrors: true,
+  },
+
   optimize: {
     optimize: true,
     obfuscate: true,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ e.g. -Werror, -P plugin..., -Xcoroutines=... etc., however this is not supported
 box (the reason probably being so that it doesn't conflict with flags already added by Soong).
 
 The following patch in AOSP:
-https://android-review.googlesource.com/c/platform/build/soong/+/735669/5
+https://android-review.googlesource.com/c/platform/build/soong/+/735669
 adds support for kotlinc flags. See [Android.bp](Android.bp)
 file for usage.
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ e.g. -Werror, -P plugin..., -Xcoroutines=... etc., however this is not supported
 box (the reason probably being so that it doesn't conflict with flags already added by Soong).
 
 The following patch in AOSP:
-https://android-review.googlesource.com/c/platform/build/soong/+/735669
-adds support for coroutines and treating warnings as errors. See [Android.bp](Android.bp)
+https://android-review.googlesource.com/c/platform/build/soong/+/735669/5
+adds support for kotlinc flags. See [Android.bp](Android.bp)
 file for usage.
 
 ### Library support

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Soong invokes kotlinc for compilation, so it would be useful to add certain flag
 e.g. -Werror, -P plugin..., -Xcoroutines=... etc., however this is not supported out of
 box (the reason probably being so that it doesn't conflict with flags already added by Soong).
 
+The following patch in AOSP:
+https://android-review.googlesource.com/c/platform/build/soong/+/735669
+adds support for coroutines and treating warnings as errors. See [Android.bp](Android.bp)
+file for usage.
+
 ### Library support
 * Kotlinc plugins not supported, e.g. kapt and Kotlin Android extensions plugin
 * Kotlin extensions libraries from Jetpack are not supported, as they are not part of the


### PR DESCRIPTION
Kotlinc flags are now supported in AOSP (see https://android-review.googlesource.com/c/platform/build/soong/+/735669).